### PR TITLE
Add exclude request option

### DIFF
--- a/R/osrmIsochrone.R
+++ b/R/osrmIsochrone.R
@@ -5,6 +5,7 @@
 #' @param loc a numeric vector of longitude and latitude (WGS84) or a 
 #' SpatialPointsDataFrame or a SpatialPolygonsDataFrame of the origine point.
 #' @param breaks a numeric vector of isochrone values (in minutes).
+#' @param exclude pass an optional "exclude" request option to the OSRM API. 
 #' @param res number of points used to compute isochrones, one side of the square 
 #' grid, the total number of points will be res*res.  
 #' @return A SpatialPolygonsDateFrame of isochrones is returned. 
@@ -58,7 +59,7 @@
 #' }
 #' }
 osrmIsochrone <- function(loc, breaks = seq(from = 0,to = 60, length.out = 7), 
-                          res = 30){
+                          exclude = NULL, res = 30){
   oprj <- NA
   if(testSp(loc)){
     oprj <- sp::proj4string(loc)
@@ -109,19 +110,19 @@ osrmIsochrone <- function(loc, breaks = seq(from = 0,to = 60, length.out = 7),
     for (i in 1:f500){
       st <- (i-1) * 300 + 1
       en <- i * 300
-      dmat <- osrmTable(src = loc, dst = sgrid[st:en,])
+      dmat <- osrmTable(src = loc, dst = sgrid[st:en,], exclude = exclude)
       durations <- dmat$durations
       listDur[[i]] <- dmat$durations
       listDest[[i]] <- dmat$destinations
       Sys.sleep(sleeptime)
     }
     if(r500>0){
-      dmat <- osrmTable(src = loc, dst = sgrid[(en+1):(en+r500),])
+      dmat <- osrmTable(src = loc, dst = sgrid[(en+1):(en+r500),], exclude = exclude)
       listDur[[i+1]] <- dmat$durations
       listDest[[i+1]] <- dmat$destinations
     }
   }else{
-    dmat <- osrmTable(src = loc, dst = sgrid)
+    dmat <- osrmTable(src = loc, dst = sgrid, exclude = exclude)
     listDur[[1]] <- dmat$durations
     listDest[[1]] <- dmat$destinations
   }

--- a/R/osrmRoute.R
+++ b/R/osrmRoute.R
@@ -67,7 +67,7 @@ osrmRoute <- function(src, dst, overview = "simplified", exclude = NULL, sp = FA
     }
     
     exclude_str <- ""
-    if (!is.null(exclude)) { exclude_str <- paste("&exclude=", exclude) }
+    if (!is.null(exclude)) { exclude_str <- paste("&exclude=", exclude, sep = "") }
     
     # build the query
     req <- paste(getOption("osrm.server"),
@@ -75,7 +75,7 @@ osrmRoute <- function(src, dst, overview = "simplified", exclude = NULL, sp = FA
                  src[2], ",", src[3], ";", dst[2],",",dst[3], 
                  "?alternatives=false&geometries=polyline&steps=false&overview=",
                  tolower(overview), exclude_str, sep="")
-    
+
     # Sending the query
     resRaw <- RCurl::getURL(utils::URLencode(req),
                             useragent = "'osrm' R package")

--- a/R/osrmRoute.R
+++ b/R/osrmRoute.R
@@ -10,6 +10,7 @@
 #' point.
 #' @param overview "full", "simplified" or FALSE. Add geometry either full (detailed), simplified 
 #' according to highest zoom level it could be display on, or not at all. 
+#' @param exclude pass an optional "exclude" request option to the OSRM API. 
 #' @param sp if sp is TRUE the function returns a SpatialLinesDataFrame.
 #' @return If sp is FALSE, a data frame is returned. It contains the longitudes and latitudes of 
 #' the travel path between the two points.\cr
@@ -50,7 +51,7 @@
 #' route3@data
 #' }
 #' @export
-osrmRoute <- function(src, dst, overview = "simplified", sp = FALSE){
+osrmRoute <- function(src, dst, overview = "simplified", exclude = NULL, sp = FALSE){
   tryCatch({
     oprj <- NA
     if(testSp(src)){
@@ -65,13 +66,16 @@ osrmRoute <- function(src, dst, overview = "simplified", sp = FALSE){
       dst <- c(x[1,1],x[1,2], x[1,3])
     }
     
+    exclude_str <- ""
+    if (!is.null(exclude)) { exclude_str <- paste("&exclude=", exclude) }
+    
     # build the query
     req <- paste(getOption("osrm.server"),
                  "route/v1/", getOption("osrm.profile"), "/", 
                  src[2], ",", src[3], ";", dst[2],",",dst[3], 
                  "?alternatives=false&geometries=polyline&steps=false&overview=",
-                 tolower(overview), sep="")
-
+                 tolower(overview), exclude_str, sep="")
+    
     # Sending the query
     resRaw <- RCurl::getURL(utils::URLencode(req),
                             useragent = "'osrm' R package")

--- a/R/osrmTable.R
+++ b/R/osrmTable.R
@@ -13,6 +13,7 @@
 #' @param dst a data frame containing destination points identifiers, longitudes 
 #' and latitudes (WGS84). It can also be a SpatialPointsDataFrame or a 
 #' SpatialPolygonsDataFrame, then row names are used as identifiers. 
+#' @param exclude pass an optional "exclude" request option to the OSRM API. 
 #' @param gepaf a boolean indicating if coordinates are sent encoded with the
 #' google encoded algorithm format (TRUE) or not (FALSE). Must be FALSE if using
 #' the public OSRM API.
@@ -56,7 +57,7 @@
 #' distA4$durations[1:5,1:5]
 #' }
 #' @export
-osrmTable <- function(loc, src = NULL, dst = NULL, gepaf = FALSE){
+osrmTable <- function(loc, src = NULL, dst = NULL, exclude = NULL, gepaf = FALSE){
   tryCatch({
     if (is.null(src)){
       # check if inpout is sp, transform and name columns
@@ -87,14 +88,17 @@ osrmTable <- function(loc, src = NULL, dst = NULL, gepaf = FALSE){
       # Build the query
       loc <- rbind(src, dst)
 
+      exclude_str <- ""
+      if (!is.null(exclude)) { exclude_str <- paste("&exclude=", exclude, sep = "") }
+      
       req <- paste(tableLoc(loc = loc, gepaf = gepaf),
                    "?sources=", 
                    paste(0:(nrow(src)-1), collapse = ";"), 
                    "&destinations=", 
-                   paste(nrow(src):(nrow(loc)-1), collapse = ";"), 
+                   paste(nrow(src):(nrow(loc)-1), collapse = ";"), exclude_str, 
                    sep="")
     }
-    
+    print(req)
     req <- utils::URLencode(req)
 
     osrmLimit(nSrc = nrow(src), nDst = nrow(dst), nreq = nchar(req))

--- a/R/osrmTrip.R
+++ b/R/osrmTrip.R
@@ -4,6 +4,7 @@
 #' This function interfaces the \emph{trip} OSRM service. 
 #' @param loc a SpatialPointsDataFrame of the waypoints, or a data.frame with points as rows
 #' and 3 columns: identifier, longitudes and latitudes (WGS84 decimal degrees).
+#' @param exclude pass an optional "exclude" request option to the OSRM API. 
 #' @param overview "full", "simplified". Add geometry either full (detailed) or simplified 
 #' according to highest zoom level it could be display on. 
 #' @details As stated in the OSRM API, if input coordinates can not be joined by a single trip 
@@ -55,7 +56,7 @@
 #'   plot(apotheke.sp[1:10,], pch = 21, bg = "red", cex = 1, add=T)
 #' }
 #' }
-osrmTrip <- function(loc, overview = "simplified"){
+osrmTrip <- function(loc, exclude = NULL, overview = "simplified"){
   tryCatch({
     # check if inpout is sp, transform and name columns
     oprj <- NA
@@ -66,11 +67,14 @@ osrmTrip <- function(loc, overview = "simplified"){
       names(loc) <- c("id", "lon", "lat")
     }
     
+    exclude_str <- ""
+    if (!is.null(exclude)) { exclude_str <- paste("&exclude=", exclude, sep = "") }
+    
     req <- paste(getOption("osrm.server"),
                  "trip/v1/", getOption("osrm.profile"), "/", 
                  paste(loc$lon, loc$lat, sep=",",collapse = ";"),
                  "?steps=false&geometries=geojson&overview=",
-                 tolower(overview), sep = "")
+                 tolower(overview), exclude_str, sep = "")
 
     osrmLimit(nSrc = nrow(loc), nDst = 0, nreq=1)
     # Send the query

--- a/R/osrmTrip.R
+++ b/R/osrmTrip.R
@@ -33,6 +33,17 @@
 #' plot(trips[[1]]$trip, col = c("red", "white"), lwd = 1, add=T)
 #' points(apotheke.df[, 2:3], pch = 21, bg = "red", cex = 1)
 #' 
+#' # Do not route through motorways
+#' trips_no_motorway <- osrmTrip(loc = apotheke.df, exclude = "motorway")
+#' 
+#' # Looks like it is more convenient to avoid motorways...
+#' mapply(`/`, trips_no_motorway[[1]]$summary, trips[[1]]$summary)
+#' 
+#' # Display the trips
+#' plot(trips[[1]]$trip, col = "black", lwd = 3)
+#' plot(trips_no_motorway[[1]]$trip, col = "green", lwd = 3, add = T)
+#' points(apotheke.df[, 2:3], pch = 21, bg = "red", cex = 1)
+#' 
 #' # Map
 #' if(require("cartography")){
 #'   osm <- getTiles(x = trips[[1]]$trip, crop = TRUE,

--- a/man/osrmIsochrone.Rd
+++ b/man/osrmIsochrone.Rd
@@ -5,13 +5,15 @@
 \title{Get a SpatialPolygonsDataFrame of Isochrones}
 \usage{
 osrmIsochrone(loc, breaks = seq(from = 0, to = 60, length.out = 7),
-  res = 30)
+  exclude = NULL, res = 30)
 }
 \arguments{
 \item{loc}{a numeric vector of longitude and latitude (WGS84) or a 
 SpatialPointsDataFrame or a SpatialPolygonsDataFrame of the origine point.}
 
 \item{breaks}{a numeric vector of isochrone values (in minutes).}
+
+\item{exclude}{pass an optional "exclude" request option to the OSRM API.}
 
 \item{res}{number of points used to compute isochrones, one side of the square 
 grid, the total number of points will be res*res.}

--- a/man/osrmRoute.Rd
+++ b/man/osrmRoute.Rd
@@ -4,7 +4,7 @@
 \alias{osrmRoute}
 \title{Get the Shortest Path Between Two Points}
 \usage{
-osrmRoute(src, dst, overview = "simplified", sp = FALSE)
+osrmRoute(src, dst, overview = "simplified", exclude = NULL, sp = FALSE)
 }
 \arguments{
 \item{src}{a numeric vector of identifier, longitude and latitude (WGS84), a 
@@ -17,6 +17,8 @@ point.}
 
 \item{overview}{"full", "simplified" or FALSE. Add geometry either full (detailed), simplified 
 according to highest zoom level it could be display on, or not at all.}
+
+\item{exclude}{pass an optional "exclude" request option to the OSRM API.}
 
 \item{sp}{if sp is TRUE the function returns a SpatialLinesDataFrame.}
 }

--- a/man/osrmTable.Rd
+++ b/man/osrmTable.Rd
@@ -4,7 +4,7 @@
 \alias{osrmTable}
 \title{Get Travel Time Matrices Between Points}
 \usage{
-osrmTable(loc, src = NULL, dst = NULL, gepaf = FALSE)
+osrmTable(loc, src = NULL, dst = NULL, exclude = NULL, gepaf = FALSE)
 }
 \arguments{
 \item{loc}{a data frame containing 3 fields: points identifiers, longitudes 
@@ -20,6 +20,8 @@ If dst and src parameters are used, only pairs between scr/dst are computed.}
 \item{dst}{a data frame containing destination points identifiers, longitudes 
 and latitudes (WGS84). It can also be a SpatialPointsDataFrame or a 
 SpatialPolygonsDataFrame, then row names are used as identifiers.}
+
+\item{exclude}{pass an optional "exclude" request option to the OSRM API.}
 
 \item{gepaf}{a boolean indicating if coordinates are sent encoded with the
 google encoded algorithm format (TRUE) or not (FALSE). Must be FALSE if using

--- a/man/osrmTrip.Rd
+++ b/man/osrmTrip.Rd
@@ -4,11 +4,13 @@
 \alias{osrmTrip}
 \title{Get the Travel Geometry Between Multiple Unordered Points}
 \usage{
-osrmTrip(loc, overview = "simplified")
+osrmTrip(loc, exclude = NULL, overview = "simplified")
 }
 \arguments{
 \item{loc}{a SpatialPointsDataFrame of the waypoints, or a data.frame with points as rows
 and 3 columns: identifier, longitudes and latitudes (WGS84 decimal degrees).}
+
+\item{exclude}{pass an optional "exclude" request option to the OSRM API.}
 
 \item{overview}{"full", "simplified". Add geometry either full (detailed) or simplified 
 according to highest zoom level it could be display on.}

--- a/man/osrmTrip.Rd
+++ b/man/osrmTrip.Rd
@@ -48,6 +48,17 @@ plot(trips[[1]]$trip, col = "black", lwd = 4)
 plot(trips[[1]]$trip, col = c("red", "white"), lwd = 1, add=T)
 points(apotheke.df[, 2:3], pch = 21, bg = "red", cex = 1)
 
+# Do not route through motorways
+trips <- osrmTrip(loc = apotheke.df, exclude = "motorway")
+
+# Looks like it is more convenient to avoid motorways...
+mapply(`/`, trips_no_motorway[[1]]$summary, trips[[1]]$summary)
+
+# Display the trips
+plot(trips[[1]]$trip, col = "black", lwd = 3)
+plot(trips_no_motorway[[1]]$trip, col = "green", lwd = 3, add = T)
+points(apotheke.df[, 2:3], pch = 21, bg = "red", cex = 1)
+
 # Map
 if(require("cartography")){
   osm <- getTiles(x = trips[[1]]$trip, crop = TRUE,

--- a/man/osrmTrip.Rd
+++ b/man/osrmTrip.Rd
@@ -49,7 +49,7 @@ plot(trips[[1]]$trip, col = c("red", "white"), lwd = 1, add=T)
 points(apotheke.df[, 2:3], pch = 21, bg = "red", cex = 1)
 
 # Do not route through motorways
-trips <- osrmTrip(loc = apotheke.df, exclude = "motorway")
+trips_no_motorway <- osrmTrip(loc = apotheke.df, exclude = "motorway")
 
 # Looks like it is more convenient to avoid motorways...
 mapply(`/`, trips_no_motorway[[1]]$summary, trips[[1]]$summary)


### PR DESCRIPTION
Hello,

I was wondering whether you had plans of adding support for more request options such as "exclude". The PR adds this support for the `osrmRoute` function. The package would gain a lot of flexibility IMHO. allowing, for example, to exclude motorways from resulting routes, eg:

    osrm::osrmRoute(
      src = c("A", 13.23889, 52.54250), 
      dst = c("B", 13.45363, 52.42926), 
      overview = "full", 
      exclude  = "motorway", 
      sp       = TRUE)